### PR TITLE
Updated documentation how to run gazebo/blender

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
 FROM ros:foxy
 
+RUN apt-get update
+RUN apt install -y wget
+
+RUN sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+RUN cat /etc/apt/sources.list.d/gazebo-stable.list
+RUN wget https://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+RUN apt-get update
+RUN apt-get install -y gazebo11 libgazebo11-dev
+RUN rm -rf /var/lib/apt/lists/*
+
 RUN mkdir -p /ros2_home/src
 
 WORKDIR /ros2_home/src
-
-CMD ["bash", "-c", "colcon build --packages-select robot_prototype && \
-. install/local_setup.bash && \
-ros2 launch robot_prototype robot_prototype_launch.py && \
-tail -f /dev/null"]

--- a/DockerfileBlender
+++ b/DockerfileBlender
@@ -1,0 +1,5 @@
+FROM debian:stretch-slim
+
+RUN apt-get update
+RUN apt install -y blender
+RUN rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -15,5 +15,37 @@ docker run robot_prototype
 ## Run the robot prototype package in ROS2 platform container
 ```bash
 docker build -f Dockerfile -t robot-with-ros2 .
-docker run --rm -v ${PWD}/robot_prototype:/ros2_home/src/robot_prototype robot-with-ros2
+docker run --rm -v ${PWD}/robot_prototype:/ros2_home/src/robot_prototype robot-with-ros2 bash -c "colcon build \
+--packages-select robot_prototype && . install/local_setup.bash && \
+ros2 launch robot_prototype robot_prototype_launch.py"
+```
+
+## Run Gazebo inside ROS2 container
+
+```bash
+xhost +
+docker build -f Dockerfile -t robot-with-ros2 .
+docker run -it \
+--device=/dev/dri \
+--group-add video \
+--volume=/tmp/.X11-unix:/tmp/.X11-unix \
+--env="DISPLAY=$DISPLAY" \
+--name gazebo-simulation-with-ros2 \
+robot-with-ros2 gazebo \
+gazebo
+```
+
+## Modeling with Blender in Docker
+```bash
+xhost +
+docker build -f DockerfileBlender -t blender-in-docker .
+docker run -it \
+-v ${PWD}/models:/models \
+--device=/dev/dri \
+--group-add video \
+--volume=/tmp/.X11-unix:/tmp/.X11-unix \
+--env="DISPLAY=$DISPLAY" \
+--name blender \
+blender-in-docker \
+blender
 ```

--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,6 @@
+# Models
+
+The models folder will contain models in common formats that can be converted and used for
+simulating 3D model robots with Gazebo and ROS2 platform.
+
+Formats that can be stored here is .STL, .OBJ, .FBX, .DAE, .3DS, .IGES, .STEP, VRML/X3D, .AMF and .3MF.


### PR DESCRIPTION
Updated README.md how to run Gazebo with ros2 image and how to run
Blender 3D modeling tool in Docker.

Updated ros2 Dockerfile to include Gazebo for future robot
simulations.

Added a Blender Dockerfile to be able to create 3D models to avoid
unnessesary dependency issues that are platform dependent.