### PR TITLE
Compile WINE 32/64 bit with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,17 @@ source ~/.bashrc # Source the latest environment variables made in the watch_fus
 #  You might need to change graphic rendering driver from auto to 'DirectX 9'/OpenGL to get the rendering working
 WINEPREFIX="${WINE_PATH}" WINEARCH="${ARCHITECTURE}" ${WINE} "${FUSION_360_EXE}" 
 ```
+
+## Compile WINE i386/amd64 in Docker
+```bash
+xhost +
+docker build -f wine_from_source/Dockerfile -t wine-in-docker .
+docker run -it \
+-v ${PWD}/models:/models \
+--device=/dev/dri \
+--group-add video \
+--volume=/tmp/.X11-unix:/tmp/.X11-unix \
+--env="DISPLAY=$DISPLAY" \
+--name install-wine-from-source \
+wine-in-docker
+```

--- a/wine_from_source/Dockerfile
+++ b/wine_from_source/Dockerfile
@@ -1,0 +1,127 @@
+FROM debian:buster-slim as amd64
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -y
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget gnupg2 software-properties-common libvulkan* \
+fakeroot dh-make git
+
+RUN add-apt-repository 'deb http://deb.debian.org/debian buster-backports main'
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y checkinstall
+
+RUN useradd -rm -d /home/ubuntu -s /bin/bash -g root -G sudo -u 1001 ubuntu
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN echo 'ubuntu:ubuntu' | chpasswd
+
+USER root
+
+RUN wget -nc https://dl.winehq.org/wine-builds/winehq.key
+RUN apt-key add winehq.key
+
+RUN add-apt-repository 'deb https://dl.winehq.org/wine-builds/debian/ buster main'
+
+RUN echo "deb-src https://dl.winehq.org/wine-builds/debian/ buster main" >> /etc/apt/sources.list
+RUN DEBIAN_FRONTEND=noninteractive apt-get update
+ARG WINE_VERSION="6.19~buster"
+ARG WINE_DEB_VERSION="${WINE_VERSION}-1"
+
+RUN DEBIAN_FRONTEND=noninteractive apt build-dep -y wine="${WINE_DEB_VERSION}"
+
+RUN git clone -b "wine-6.19" git://source.winehq.org/git/wine.git /usr/src/wine-source
+RUN mkdir -p /usr/src/wine64
+
+WORKDIR /usr/src/wine64
+
+RUN exec /bin/bash -c '../wine-source/configure --enable-win64 --prefix=/usr'
+RUN exec /bin/bash -c 'make -j7'
+RUN exec /bin/bash -c 'checkinstall -D --pkgname=wine-local --pkgversion=6.19 --nodoc --install=no'
+
+FROM i386/debian:buster-slim as i386
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -y
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget gnupg2 software-properties-common libvulkan* \
+fakeroot dh-make git
+
+RUN add-apt-repository 'deb http://deb.debian.org/debian buster-backports main'
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y checkinstall
+
+RUN useradd -rm -d /home/ubuntu -s /bin/bash -g root -G sudo -u 1001 ubuntu
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN echo 'ubuntu:ubuntu' | chpasswd
+
+USER root
+
+RUN wget -nc https://dl.winehq.org/wine-builds/winehq.key
+RUN apt-key add winehq.key
+
+RUN add-apt-repository 'deb https://dl.winehq.org/wine-builds/debian/ buster main'
+
+RUN echo "deb-src https://dl.winehq.org/wine-builds/debian/ buster main" >> /etc/apt/sources.list
+RUN DEBIAN_FRONTEND=noninteractive apt-get update
+ARG WINE_VERSION="6.19~buster"
+ARG WINE_DEB_VERSION="${WINE_VERSION}-1"
+
+RUN DEBIAN_FRONTEND=noninteractive apt build-dep -y wine="${WINE_DEB_VERSION}"
+
+RUN mkdir -p /usr/src/wine32 /usr/src/wine32-tools
+COPY --from=amd64 /usr/src/wine-source /usr/src/wine-source
+COPY --from=amd64 /usr/src/wine64 /usr/src/wine64
+
+WORKDIR /usr/src/wine32-tools
+
+RUN exec /bin/bash -c '../wine-source/configure'
+RUN exec /bin/bash -c 'make -j7'
+
+WORKDIR /usr/src/wine32
+
+RUN exec /bin/bash -c '../wine-source/configure --with-wine64=../wine64 --with-wine-tools=../wine32-tools --prefix=/usr'
+RUN exec /bin/bash -c 'make -j7'
+RUN exec /bin/bash -c 'checkinstall -D --pkgname=wine-local --pkgversion=6.19 --nodoc --install=no'
+
+FROM debian:buster-slim
+
+RUN dpkg --add-architecture i386
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get upgrade -y
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget gnupg2 software-properties-common libvulkan* sudo
+
+RUN useradd -rm -d /home/ubuntu -s /bin/bash -g root -G sudo -u 1001 ubuntu
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN echo 'ubuntu:ubuntu' | chpasswd
+
+USER root
+
+RUN wget -nc https://dl.winehq.org/wine-builds/winehq.key
+RUN apt-key add winehq.key
+
+RUN add-apt-repository 'deb https://dl.winehq.org/wine-builds/debian/ buster main'
+
+RUN echo "deb-src https://dl.winehq.org/wine-builds/debian/ buster main" >> /etc/apt/sources.list
+RUN DEBIAN_FRONTEND=noninteractive apt-get update
+ARG WINE_VERSION="6.19~buster"
+ARG WINE_DEB_VERSION="${WINE_VERSION}-1"
+
+RUN DEBIAN_FRONTEND=noninteractive apt build-dep -y wine="${WINE_DEB_VERSION}"
+
+WORKDIR /home/ubuntu
+
+COPY --from=amd64 /usr/src/wine64/*.deb /home/ubuntu/.
+COPY --from=i386 /usr/src/wine32/*.deb /home/ubuntu/.
+
+USER root
+
+RUN dpkg -i wine-local_6.19-1_i386.deb
+RUN dpkg -i wine-local_6.19-1_amd64.deb
+
+ENV HOME_PATH="/home/ubuntu"
+ENV WINE_PATH="${HOME_PATH}/.wine"
+ENV ARCHITECTURE="win64"
+ENV WINE="wine64"
+
+RUN rm -rf /var/lib/apt/lists/*
+
+USER ubuntu
+
+RUN echo "export HOME_PATH=${HOME_PATH}" >> "${HOME_PATH}/.bashrc"
+RUN echo "export WINE_PATH=${WINE_PATH}" >> "${HOME_PATH}/.bashrc"
+RUN echo "export ARCHITECTURE=${ARCHITECTURE}" >> "${HOME_PATH}/.bashrc"
+RUN echo "export WINE=${WINE}" >> "${HOME_PATH}/.bashrc"


### PR DESCRIPTION
Compile WINE 32/64 bit from scratch with help of Docker Debian
32/64 bit architecture and install it easily as debian packages.

Configured a Dockerfile to compile WINE 32/64 bit architecture from
scratch and install it as debian packages in a Debian buster distro
64/32 bit environment.