### PR TITLE
Refactoring WoW64 build

### DIFF
--- a/wine_from_source/Dockerfile
+++ b/wine_from_source/Dockerfile
@@ -5,7 +5,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget gnupg2 software-prope
 fakeroot dh-make git libasound2-dev libdbus-1-dev libfontconfig-dev libfreetype6-dev libgnutls28-dev libpng-dev \
 libtiff-dev libgl-dev libunwind-dev libxml2-dev libxslt1-dev libgstreamer1.0-dev \
 libgstreamer-plugins-base1.0-dev libmpg123-dev libosmesa6-dev libsdl2-dev libudev-dev libvulkan-dev \
-ocl-icd-opencl-dev libusb-1.0-0-dev libjxr-dev libgtk2.0-0 mesa-vulkan-drivers gcc-mingw-w64
+ocl-icd-opencl-dev libusb-1.0-0-dev libjxr-dev libgtk2.0-0 mesa-vulkan-drivers gcc-mingw-w64 \
+pkg-config
 
 RUN add-apt-repository 'deb http://deb.debian.org/debian buster-backports main'
 RUN apt-get update
@@ -37,9 +38,8 @@ RUN mkdir -p /usr/src/wine64
 
 WORKDIR /usr/src/wine64
 
-RUN exec /bin/bash -c '../wine-source/configure --enable-win64 --prefix=/usr'
+RUN exec /bin/bash -c 'PKG_CONFIG_PATH=/usr/lib/pkgconfig ../wine-source/configure --enable-win64 --prefix=/opt/wine-staging'
 RUN exec /bin/bash -c 'make -j7'
-RUN exec /bin/bash -c 'checkinstall -D --pkgname=wine-local --pkgversion=6.19 --nodoc --install=no'
 
 FROM i386/debian:buster-slim as i386
 
@@ -48,7 +48,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget gnupg2 software-prope
 fakeroot dh-make git libasound2-dev libdbus-1-dev libfontconfig-dev libfreetype6-dev libgnutls28-dev libpng-dev \
 libtiff-dev libgl-dev libunwind-dev libxml2-dev libxslt1-dev libgstreamer1.0-dev \
 libgstreamer-plugins-base1.0-dev libmpg123-dev libosmesa6-dev libsdl2-dev libudev-dev libvulkan-dev \
-ocl-icd-opencl-dev libusb-1.0-0-dev libjxr-dev libgtk2.0-0 mesa-vulkan-drivers gcc-mingw-w64
+ocl-icd-opencl-dev libusb-1.0-0-dev libjxr-dev libgtk2.0-0 mesa-vulkan-drivers gcc-mingw-w64 \
+pkg-config
 
 RUN add-apt-repository 'deb http://deb.debian.org/debian buster-backports main'
 RUN apt-get update
@@ -81,14 +82,14 @@ COPY --from=amd64 /usr/src/wine64 /usr/src/wine64
 
 WORKDIR /usr/src/wine32-tools
 
-RUN exec /bin/bash -c '../wine-source/configure'
+RUN exec /bin/bash -c 'PKG_CONFIG_PATH=/usr/lib/pkgconfig ../wine-source/configure'
 RUN exec /bin/bash -c 'make -j7'
 
 WORKDIR /usr/src/wine32
 
-RUN exec /bin/bash -c '../wine-source/configure --with-wine64=../wine64 --with-wine-tools=../wine32-tools --prefix=/usr'
+RUN exec /bin/bash -c 'PKG_CONFIG_PATH=/usr/lib/pkgconfig ../wine-source/configure --with-wine64=../wine64 --with-wine-tools=../wine32-tools --prefix=/opt/wine-staging'
 RUN exec /bin/bash -c 'make -j7'
-RUN exec /bin/bash -c 'checkinstall -D --pkgname=wine-local --pkgversion=6.19 --nodoc --install=no'
+RUN exec /bin/bash -c 'checkinstall -D --pkgname=wine-local --pkgversion=6.19 --nodoc --install=yes'
 
 FROM debian:buster-slim
 
@@ -98,9 +99,20 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget gnupg2 software-prope
 libasound2-dev libdbus-1-dev libfontconfig-dev libfreetype6-dev libgnutls28-dev libpng-dev \
 libtiff-dev libgl-dev libunwind-dev libxml2-dev libxslt1-dev libgstreamer1.0-dev \
 libgstreamer-plugins-base1.0-dev libmpg123-dev libosmesa6-dev libsdl2-dev libudev-dev libvulkan-dev \
-ocl-icd-opencl-dev libusb-1.0-0-dev libjxr-dev libgtk2.0-0 mesa-vulkan-drivers gcc-mingw-w64 cabextract \
+ocl-icd-opencl-dev libusb-1.0-0-dev libjxr-dev libgtk2.0-0 mesa-vulkan-drivers gcc-mingw-w64 \
+cabextract pkg-config \
 sudo procps curl cabextract wget software-properties-common winbind libvulkan1 vulkan-utils xterm apt-utils \
 zenity libnss3 p7zip p7zip-full sed xvfb vim mesa-utils
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y libasound2-dev:i386 libdbus-1-dev:i386 libfontconfig-dev:i386 \
+libfreetype6-dev:i386 libgnutls28-dev:i386 libpng-dev:i386 libtiff-dev:i386 libgl-dev:i386 libunwind-dev:i386 \
+libxml2-dev:i386 libxslt1-dev:i386 libgstreamer1.0-dev:i386 libgstreamer-plugins-base1.0-dev:i386 libmpg123-dev:i386 \
+libosmesa6-dev:i386 libsdl2-dev:i386 libudev-dev:i386 libvulkan-dev:i386 ocl-icd-opencl-dev:i386 libusb-1.0-0-dev:i386 \
+libjxr-dev:i386 libgtk2.0-0:i386 mesa-vulkan-drivers:i386 pkg-config:i386
+
+RUN add-apt-repository 'deb http://deb.debian.org/debian buster-backports main'
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y checkinstall libfaudio-dev
 
 RUN useradd -rm -d /home/ubuntu -s /bin/bash -g root -G sudo -u 1001 ubuntu
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -126,16 +138,27 @@ RUN chmod +x /usr/bin/winetricks
 WORKDIR /home/ubuntu
 
 COPY --from=amd64 /oss-linux-v4.2-2020-amd64.deb /home/ubuntu/.
-COPY --from=amd64 /usr/src/wine64/*.deb /home/ubuntu/.
-COPY --from=i386 /usr/src/wine32/*.deb /home/ubuntu/.
+COPY --from=amd64 /usr/src/wine-source /home/ubuntu/wine-source
+COPY --from=amd64 /usr/src/wine64 /home/ubuntu/wine64
+COPY --from=i386 /opt/wine-staging /opt/wine-staging
+COPY --from=i386 /lib /lib
 
 USER root
 
-RUN dpkg -i wine-local_6.19-1_i386.deb
 RUN dpkg -i oss-linux-v4.2-2020-amd64.deb
-RUN dpkg -i wine-local_6.19-1_amd64.deb
+
+WORKDIR /home/ubuntu/wine64
+
+RUN exec /bin/bash -c 'checkinstall -D --pkgname=wine-local --pkgversion=6.19 --nodoc --install=yes'
+
+WORKDIR /home/ubuntu
 
 RUN rm -fr *.deb
+RUN rm -fr wine*
+
+RUN ln -s /opt/wine-staging/bin/wine64 /usr/bin/wine64
+RUN ln -s /opt/wine-staging/bin/wine /usr/bin/wine
+RUN ln -s /opt/wine-staging/bin/wineserver /usr/bin/wineserver
 
 ENV HOME_PATH="/home/ubuntu"
 ENV WINE_PATH="${HOME_PATH}/.wine"


### PR DESCRIPTION
Refactored WoW64 build to install WINE 32/64 bit architecture on
specific /opt/wine-staging directory with updated library dependencies
to work better executing 32/64 bit applications in a container
context.